### PR TITLE
Bugfix: Changes in all files leads to full reload

### DIFF
--- a/vite.fluid.js
+++ b/vite.fluid.js
@@ -1,14 +1,17 @@
 export default function ViteFluid() {
-  return {
-    name: 'ViteFluid',
-    enforce: 'post',
-    configureServer(server) {
-      const fullReload = () => {
-        server.ws.send({ type: 'full-reload', path: '*' });
-      };
-      server.watcher.add(['./**/*.html', './**/*.typoscript', './**/*.yaml', './**/*.php']);
-      server.watcher.on('add', fullReload);
-      server.watcher.on('change', fullReload);
-    },
-  }
+    return {
+        name: 'ViteFluid',
+        enforce: 'post',
+        configureServer(server) {
+            const fullReload = () => {
+                server.ws.send({type: 'full-reload', path: '*'});
+            };
+            server.watcher.on('add', fullReload);
+            server.watcher.on('change', (file) =>{
+                if (file.endsWith('.html') || file.endsWith('.typoscript') || file.endsWith('.yaml') || file.endsWith('.php')) {
+                    fullReload();
+                }
+            });
+        },
+    }
 }


### PR DESCRIPTION
Solution: Check file endings on change callback to trigger reload only on specific files.  Adding file endings in server.watcher.add seems not to be necessary.

<a href="https://gitpod.io/#https://github.com/fgeierst/typo3-vite-demo/pull/25"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

